### PR TITLE
security: pin third-party GitHub Actions to commit SHAs + least-privilege permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,6 +2,9 @@ name: CI
 
 env: {}
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]
@@ -27,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # setup conda
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@9f54435e0e72c53962ee863144e47a4b094bfd35 # v2
         with:
           auto-update-conda: true
           activate-environment: testenv


### PR DESCRIPTION
## What

- Pin all third-party GitHub Actions used in `.github/workflows/` to full 40-char commit SHAs, retaining a trailing `# version` comment for readability.
- Add a top-level least-privilege `permissions:\n  contents: read` block to the pure-CI workflow (`CI.yml`), which has no privileged operations.

## Why

Supply-chain hardening per group convention (pin third-party actions to SHA hashes where possible). From the 2026-06-22 workspace GitHub Actions security audit.

## Pins applied

- `conda-incubator/setup-miniconda@v2` -> `conda-incubator/setup-miniconda@9f54435e0e72c53962ee863144e47a4b094bfd35 # v2`

First-party `actions/*` (e.g. `actions/checkout@v2`) are intentionally left tag-pinned.

## Permissions

Added `permissions: contents: read` to `CI.yml` — it has no existing top-level permissions block and none of the privileged markers (no `id-token`, no `*: write`, no release/publish/PR-creation actions).

## Notes

No `dtolnay/rust-toolchain` or `taiki-e/install-action` usage in this repo, so those special-handling notes do not apply here.

No behavior change intended; CI on this PR validates.

🤖 Assisted with Claude Code
