### PR TITLE
Release 0.1.4: final pre-modernization snapshot

### DIFF
--- a/bem/_version.py
+++ b/bem/_version.py
@@ -1,4 +1,4 @@
-version_info = (0, 1, 3, 'final')
+version_info = (0, 1, 4, 'final')
 
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 


### PR DESCRIPTION
Marks the current state as **v0.1.4**, the last release before the packaging/tooling modernization (see PR #41 and the modernization issue trail).

## What this does
- Bumps `bem/_version.py` `0.1.3` → `0.1.4`.

## Why
`v0.1.3` was already tagged and released in 2022 at commit `6bf49b0`. Since then, `master` has two commits whose only change is CI GitHub Actions SHA-pinning (#39) — **no `bem/` package code changes**. Cutting `v0.1.4` here gives us a clean, taggable snapshot of the pre-modernization state (an archival baseline / versioningit anchor) instead of leaving `master` in an untagged limbo between `v0.1.3` and the upcoming rewrite.

Once merged, `v0.1.4` will be tagged at the merge commit and a GitHub release published as the archival record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)