### PR TITLE
Add security scanning: Grype dependency gate + Dependabot + code scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Dependabot keeps the SHA-pinned third-party actions fresh (one grouped
+# weekly PR), per the org convention. Python dependencies are managed by
+# pixi (pixi.lock), so no pip ecosystem is configured here.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,3 +33,27 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
+
+  # grype scans the installed pixi env (pip + conda packages), gates only on
+  # fixable findings, and uploads SARIF to the Security tab (org decision
+  # 2026-06-10: grype, not pip-audit)
+  dependency-scan:
+    name: Scan dependencies with Grype
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # required for upload-sarif
+      actions: read # upload-sarif on private repos
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
+        with:
+          manifest-path: pyproject.toml
+          environments: default
+      - name: Scan pixi environment with Grype
+        uses: neutrons/conda-actions/grype@bba9ca89d48d9ae846db9650cc63fde736340b3d # v2
+        with:
+          path: ${{ github.workspace }}/.pixi/envs/default
+          # only-fixed defaults to true in the v2 wrapper, so unfixable
+          # advisories never fail the build
+          fail-build: true

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,22 @@
+# Grype ignore rules for the CI dependency gate (org decision 2026-06-10:
+# grype, not pip-audit). Every entry needs a reason and a revisit
+# condition — this file is the reviewable record of accepted risk.
+#
+# The `default` pixi env resolves the newest conda-forge CPython (>=3.12,
+# currently the 3.14 line). Grype flags the advisories below against it,
+# but each is "fixed" only in a CPython 3.15 PRE-RELEASE (alpha/beta) —
+# there is no installable stable fix for the 3.14 line. They are accepted
+# until conda-forge ships a patched CPython that backports them (the
+# lockfile-update maintenance will pick it up). No non-python package in
+# bem's scientific stack surfaces a fixable advisory today (2026-07-08).
+
+ignore:
+  - vulnerability: CVE-2025-15366 # Medium; fixed in 3.15.0a6 (prerelease), no 3.14 backport
+    package:
+      name: python
+  - vulnerability: CVE-2025-15367 # Medium; fixed in 3.15.0a6 (prerelease), no 3.14 backport
+    package:
+      name: python
+  - vulnerability: CVE-2026-12003 # Medium; fixed in 3.15.0b3 (prerelease), no 3.14 backport
+    package:
+      name: python


### PR DESCRIPTION
Second modernization PR (security), following the foundation PR #41. Adds the fleet-standard security pipeline, modeled on iBeatles.

## Changes
- **`CI.yml` → new `dependency-scan` job**: runs **Grype** over the installed `default` pixi env via `neutrons/conda-actions/grype@…v2` (SHA-pinned), gating on **fixable** findings (`only-fixed`), and uploading **SARIF to code scanning** (`security-events: write`).
- **`.github/dependabot.yml`**: weekly grouped **github-actions** updates to keep the SHA-pinned actions fresh. (Python deps are pixi-managed via `pixi.lock`, so no `pip` ecosystem — matches the fleet; deviates from the EWM task's "pip +" wording, flagged for review.)
- **`.grype.yaml`**: curated ignore list built from **bem's own env**, not copied from iBeatles (which is Qt/PyQt5-specific). Only the **three CPython advisories** the default env surfaces are accepted — `CVE-2025-15366`, `CVE-2025-15367`, `CVE-2026-12003` — each fixed only in a **3.15 pre-release** with no installable stable backport. bem's scientific stack surfaces no other fixable advisory.

## Verification (local)
- `grype dir:.pixi/envs/default --only-fixed --fail-on medium` → **exit 0** with `.grype.yaml` (the 3 CVEs suppressed; without it they were live medium findings).
- `pixi run test` → **19 passed** (default env, py3.14).
- All three YAML files parse; `dependency-scan` perms = `contents:read, security-events:write, actions:read`.
- Dependabot alerts already enabled on the repo (`vulnerability-alerts` → 204).

## Notes
- Code scanning (Security tab) populates after this job runs on the default branch post-merge.
- Follow-up (out of scope here, an EWM task-2 gap): no `pixi.lock` is committed, so the Grype env re-solves each run (gate CVE set may drift). Committing a lock would stabilize it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)