### PR TITLE
Modernize docs: Sphinx on Python 3.12, Read the Docs, README/install refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ local-channel/
 *.conda
 pyproject.toml.bak
 braggedgemodeling/_version.py
+docs/_build/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# Read the Docs build configuration
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+version: 2
+
+build:
+  os: "ubuntu-24.04"
+  tools:
+    python: "3.12"
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CI](https://github.com/ornlneutronimaging/braggedgemodeling/actions/workflows/CI.yml/badge.svg)](https://github.com/ornlneutronimaging/braggedgemodeling/actions/workflows/CI.yml)
-[![Coverage Status](https://coveralls.io/repos/github/ornlneutronimaging/braggedgemodeling/badge.svg?branch=master)](https://coveralls.io/github/ornlneutronimaging/braggedgemodeling?branch=master)
+[![codecov](https://codecov.io/gh/ornlneutronimaging/braggedgemodeling/graph/badge.svg)](https://codecov.io/gh/ornlneutronimaging/braggedgemodeling)
 [![DOI](http://joss.theoj.org/papers/10.21105/joss.00973/status.svg)](https://doi.org/10.21105/joss.00973)
 
 # Bragg Edge Modeling
@@ -18,6 +18,32 @@ calculate neutron Bragg Edge spectrum as a function of neutron wavelength.
   - Jorgensen model
 * Flexible design to allow future extension to texture and peak profile models
 * Allow easy fitting to measured Bragg Edge data
+
+## Installation
+
+`braggedgemodeling` requires Python 3.12+.
+
+```bash
+# from PyPI
+pip install braggedgemodeling
+
+# or from conda (anaconda.org neutronimaging channel)
+conda install -c conda-forge -c neutronimaging braggedgemodeling
+```
+
+The distribution is named `braggedgemodeling` (the short name `bem` is already taken on PyPI) and the **import package is also `braggedgemodeling`**. Code written against the old `bem` module can add a one-line alias as a drop-in stop-gap:
+
+```python
+import braggedgemodeling as bem
+```
+
+For development, the project uses [pixi](https://pixi.sh/):
+
+```bash
+git clone https://github.com/ornlneutronimaging/braggedgemodeling.git
+cd braggedgemodeling
+pixi run test   # build the environment and run the test suite
+```
 
 ## Documentation
 
@@ -40,5 +66,5 @@ Please either use [the github issues](https://github.com/ornlneutronimaging/brag
 
 
 ## Known problems
-* Debye temperatures are listed in a [table](bem/DebyeTemp.py), which is missing data for some elements.
+* Debye temperatures are listed in a [table](braggedgemodeling/DebyeTemp.py), which is missing data for some elements.
   However, users can provide their own table in a [configuration file](tests/bem.conf).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI](https://github.com/ornlneutronimaging/braggedgemodeling/actions/workflows/CI.yml/badge.svg)](https://github.com/ornlneutronimaging/braggedgemodeling/actions/workflows/CI.yml)
 [![codecov](https://codecov.io/gh/ornlneutronimaging/braggedgemodeling/graph/badge.svg)](https://codecov.io/gh/ornlneutronimaging/braggedgemodeling)
-[![DOI](http://joss.theoj.org/papers/10.21105/joss.00973/status.svg)](https://doi.org/10.21105/joss.00973)
+[![DOI](https://joss.theoj.org/papers/10.21105/joss.00973/status.svg)](https://doi.org/10.21105/joss.00973)
 
 # Bragg Edge Modeling
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = bem
+SPHINXPROJ    = braggedgemodeling
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,27 +4,33 @@ API
 The braggedgemodeling package provides tools to calculate neutron Bragg Edge
 spectrum for a material.
 
+.. note::
+
+   The import package is ``braggedgemodeling``. Existing code that used the
+   old ``bem`` name can add ``import braggedgemodeling as bem`` as a drop-in
+   alias.
+
 Atomic structure
 ----------------
 
-.. autofunction:: bem.matter.loadCif
-.. autofunction:: bem.matter.Structure
+.. autofunction:: braggedgemodeling.matter.loadCif
+.. autofunction:: braggedgemodeling.matter.Structure
 
 Cross section calculator
 ------------------------
 
-.. autoclass:: bem.xscalc.XSCalculator
+.. autoclass:: braggedgemodeling.xscalc.XSCalculator
    :members:
    :special-members: __init__
-		  
+
 Texture
 -------
 
-.. autoclass:: bem.xtaloriprobmodel.MarchDollase
+.. autoclass:: braggedgemodeling.xtaloriprobmodel.MarchDollase
 
 
 Peak profile
 ------------
-.. autoclass:: bem.peak_profile.Jorgensen
+.. autoclass:: braggedgemodeling.peak_profile.Jorgensen
    :members:
    :special-members: __init__

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,14 +19,22 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'bem'
-copyright = '2017-2018, ORNL Neutron Data Sciences Group'
-author = 'ORNL Neutron Data Sciences Group'
+project = 'braggedgemodeling'
+copyright = '2017-2026, ORNL Neutron Imaging Team'
+author = 'ORNL Neutron Imaging Team'
 
+# The version is read from the installed package metadata (set by versioningit
+# at build time), so it never needs to be hand-maintained here.
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+try:
+    # The full version, including alpha/beta/rc tags
+    release = _pkg_version('braggedgemodeling')
+except PackageNotFoundError:
+    release = ''
 # The short X.Y version
-version = ''
-# The full version, including alpha/beta/rc tags
-release = '0.1.1'
+version = '.'.join(release.split('.')[:2])
 
 
 # -- General configuration ---------------------------------------------------
@@ -63,7 +71,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,7 +114,7 @@ html_static_path = ['_static']
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'bemdoc'
+htmlhelp_basename = 'braggedgemodelingdoc'
 
 
 # -- Options for LaTeX output ------------------------------------------------
@@ -141,8 +141,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'bem.tex', 'bem Documentation',
-     'ORNL Neutron Data Sciences Group', 'manual'),
+    (master_doc, 'braggedgemodeling.tex', 'braggedgemodeling Documentation',
+     author, 'manual'),
 ]
 
 
@@ -151,7 +151,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'bem', 'bem Documentation',
+    (master_doc, 'braggedgemodeling', 'braggedgemodeling Documentation',
      [author], 1)
 ]
 
@@ -162,8 +162,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'bem', 'bem Documentation',
-     author, 'bem', 'One line description of project.',
+    (master_doc, 'braggedgemodeling', 'braggedgemodeling Documentation',
+     author, 'braggedgemodeling', 'One line description of project.',
      'Miscellaneous'),
 ]
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,48 +5,50 @@ Installation
 
 Python
 ------
-The `braggedgemodeling` package depends on python version 3 (3.5, 3.6).
+``braggedgemodeling`` requires **Python 3.12 or newer**.
+
+.. note::
+
+   The distribution is named ``braggedgemodeling`` (the short name ``bem`` is
+   already taken on PyPI), and the **import package is also**
+   ``braggedgemodeling``. Code written against the old ``bem`` module can add a
+   one-line alias as a drop-in stop-gap::
+
+      import braggedgemodeling as bem
 
 
-Preferred: Install using conda
-------------------------------
+Install from PyPI (pip)
+-----------------------
 
-The preferred method for installation is to use `conda <https://conda.io/>`_.
-Please use the following commands to install `braggedgemodeling`::
+::
 
-      $ conda config --add channels conda-forge
-      $ conda install braggedgemodeling
+   $ pip install braggedgemodeling
 
-Information on dependencies of this code can be found at `the conda recipe <https://github.com/conda-forge/braggedgemodeling-feedstock/blob/master/recipe/meta.yaml>`_.
 
-      
-Using setup.py
---------------
+Install from conda (anaconda.org)
+----------------------------------
 
-It is also possible to install `braggedgemodeling` using `setup.py` script,
-but there are some hoops to jump through.
+Conda packages are published to the ``neutronimaging`` channel::
 
-.. note:: The following instructions assume an ubuntu distribution. For other platforms, please make appropriate adjustments.
+   $ conda install -c conda-forge -c neutronimaging braggedgemodeling
 
-* First, please install `pip <https://pypi.org/project/pip/>`_ for python 3 (pip3) using `apt-get`::
-	      
-   $ sudo apt-get install python3-pip
-	      
-* Then, use pip3 to install some dependencies::
 
-   $ pip3 install --user numpy pycifrw pyyaml scipy matplotlib periodictable
+From source (pixi)
+------------------
 
-* Next, please install diffpy.structure (python 3 version) from source::
-   
-   $ git clone https://github.com/diffpy/diffpy.structure
-   $ cd diffpy.structure
-   $ git checkout python3  # Important! make sure to checkout the python3 branch
-   $ python3 setup.py install --user
+The project uses `pixi <https://pixi.sh/>`_ for reproducible environments.
+To work from a clone::
 
-.. attention:: This step may fail if you have tried to install the python 2 version of diffpy.structure in the python 3 environment.
-	       If so, you may need to remove the pip cache (which should be ~/.cache/pip) before trying this step again.
-  
-* Now you can install `braggedgemodeling` by::
-     
-  $ git clone https://github.com/ornlneutronimaging/braggedgemodeling.git
-  $ cd braggedgemodeling && python3 setup.py install --user
+   $ git clone https://github.com/ornlneutronimaging/braggedgemodeling.git
+   $ cd braggedgemodeling
+   $ pixi run test        # build the environment and run the test suite
+
+Individual environments and tasks are defined in ``pyproject.toml`` (for
+example ``pixi run -e docs build-docs`` to build these docs).
+
+.. note::
+
+   The optional ``texture`` subpackage additionally requires an external
+   MATLAB + mtex + VPSC toolchain, which cannot be installed from PyPI or
+   conda and is not exercised in CI. See :doc:`api` and issue `#40
+   <https://github.com/ornlneutronimaging/braggedgemodeling/issues/40>`_.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -27,7 +27,7 @@ The first step is to create a model of the material. Here we use bcc Fe as the e
   lattice = Lattice(a=a, b=a, c=a, alpha=alpha, beta=alpha, gamma=alpha)
   astruct = Structure(atoms, lattice, sgid=229)
 
-.. note:: You can also use :code:`bem.matter.loadCif(path)` to load an atomic structure
+.. note:: You can also use :code:`braggedgemodeling.matter.loadCif(path)` to load an atomic structure
    from a CIF file::
 
      from braggedgemodeling.matter import loadCif

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ dependencies = [
 # toolchain (not installable from PyPI/conda). See docs; tracked in issue #40.
 [project.optional-dependencies]
 texture = []
+# used by the Read the Docs pip build (`.[docs]`)
+docs = ["sphinx", "sphinx-rtd-theme"]
 
 [project.urls]
 homepage = "https://github.com/ornlneutronimaging/braggedgemodeling"
@@ -142,6 +144,9 @@ reset-toml = { cmd = "cp pyproject.toml.bak pyproject.toml && rm pyproject.toml.
 [tool.pixi.feature.docs.dependencies]
 sphinx = "*"
 sphinx_rtd_theme = "*"
+
+[tool.pixi.feature.docs.tasks]
+build-docs = { cmd = "sphinx-build -b html docs docs/_build/html", description = "Build the HTML documentation" }
 
 [tool.pixi.feature.py312.dependencies]
 python = "3.12.*"


### PR DESCRIPTION
Fourth modernization PR (docs), after #41 (foundation), #43 (security), #44 (publish).

## Changes
- **`docs/conf.py`**: project `bem` → `braggedgemodeling`; version read from installed package metadata (`importlib.metadata`) instead of the stale hard-coded `release='0.1.1'`; `language='en'` (drops the deprecated `None`).
- **`docs/api.rst`**: autodoc targets `bem.*` → `braggedgemodeling.*` — these were **broken after the #41 rename** (autodoc import error) — plus an import-alias note.
- **`docs/installation.rst`**: rewritten for pip / conda (`neutronimaging`) / pixi and Python 3.12; drops the `setup.py` + py3.5 instructions; documents `import braggedgemodeling as bem` as a drop-in stop-gap.
- **`README.md`**: pip/conda/pixi install + the import-alias note; stale **coveralls badge → codecov**; fix the `bem/DebyeTemp.py` path; **JOSS DOI badge kept**.
- **`.readthedocs.yaml`** (new): v2, ubuntu-24.04/py3.12, sphinx `docs/conf.py`, `fail_on_warning: true`, pip install `.[docs]`.
- **`pyproject.toml`**: `docs` optional-dependency extra (RTD pip build) + a `build-docs` task in the docs feature.
- `docs/_static/.gitkeep` so `html_static_path` resolves (warning-free build).

## Verification
- `pixi run -e docs build-docs` → **`build succeeded.` with 0 warnings**; `docs/_build/html/index.html` produced; autodoc imports all four `braggedgemodeling.*` modules cleanly.
- Docs are not in the CI matrix, so unit-test/grype/publish jobs are unaffected (confirmed on this PR's checks).

## Note
The README doc link still points at the existing GitHub Pages URL; once the Read the Docs project is connected, it can be switched to the RTD URL (separate, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)