### PR TITLE
grype: accept CVE-2026-15308 (unfixable in the CPython 3.14 line)

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -4,11 +4,13 @@
 #
 # The `default` pixi env resolves the newest conda-forge CPython (>=3.12,
 # currently the 3.14 line). Grype flags the advisories below against it,
-# but each is "fixed" only in a CPython 3.15 PRE-RELEASE (alpha/beta) —
-# there is no installable stable fix for the 3.14 line. They are accepted
-# until conda-forge ships a patched CPython that backports them (the
-# lockfile-update maintenance will pick it up). No non-python package in
-# bem's scientific stack surfaces a fixable advisory today (2026-07-08).
+# but each is "fixed" only in the CPython 3.15 line (prerelease or the
+# eventual 3.15.0) — there is no installable fix backported to 3.14. They
+# are accepted until conda-forge ships a patched 3.14 (or the env moves to
+# a fixed 3.15); the lockfile-update maintenance will pick it up. No
+# non-python package in bem's scientific stack surfaces a fixable advisory
+# today (2026-07-13). Severity is not the gate — fixability is: an entry is
+# accepted only when no installable fix exists for the pinned interpreter.
 
 ignore:
   - vulnerability: CVE-2025-15366 # Medium; fixed in 3.15.0a6 (prerelease), no 3.14 backport
@@ -18,5 +20,8 @@ ignore:
     package:
       name: python
   - vulnerability: CVE-2026-12003 # Medium; fixed in 3.15.0b3 (prerelease), no 3.14 backport
+    package:
+      name: python
+  - vulnerability: CVE-2026-15308 # High; fixed in 3.15.0, no 3.14 backport (added 2026-07-13)
     package:
       name: python


### PR DESCRIPTION
The Grype vuln DB update (**v6.1.7, built 2026-07-12**) began flagging **CVE-2026-15308** (High) on **CPython 3.14.6**, which the `default` pixi env resolves. This turned the `Scan dependencies with Grype` gate **red on `master`** and is blocking the Dependabot PR #47 (its other checks all pass).

## Fix
Add `CVE-2026-15308` to `.grype.yaml`. It is fixed only in the CPython 3.15 line (grype: *fixed in 3.15.0*) with **no backport to 3.14**, so there is no installable fix for the pinned interpreter — the same accept-and-ignore basis as the existing entries. Per the org policy, **fixability (not severity) is the gate**: an advisory is accepted only when no installable fix exists for the pinned interpreter, with a documented reason + revisit condition.

## Verification
`grype dir:.pixi/envs/default --only-fixed --fail-on medium` → **`No vulnerabilities found`, exit 0** with the top-up (CVE-2026-15308 shows `(suppressed)`); it fails without it.

Revisit when conda-forge ships a patched 3.14 or the env moves to a fixed 3.15.

Once merged, rebasing Dependabot #47 clears its gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)