### PR TITLE
ci: make Grype non-blocking (SARIF-only)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,4 +75,4 @@ jobs:
           path: ${{ github.workspace }}/.pixi/envs/default
           # only-fixed defaults to true in the v2 wrapper, so unfixable
           # advisories never fail the build
-          fail-build: true
+          fail-build: false


### PR DESCRIPTION
Phase 1 of the Grype-policy overhaul: set `fail-build: false` on the CI.yml Grype step so it still scans + uploads SARIF to the Security tab, but never blocks a merge. Stops unrelated PRs failing on non-actionable transitive CVEs / overnight vuln-DB refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)