### PR TITLE
chore: post-release cleanup (docs link, dead master refs, gh-pages vestige)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - master
     tags:
       - "v*"
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ calculate neutron Bragg Edge spectrum as a function of neutron wavelength.
 # from PyPI
 pip install braggedgemodeling
 
-# or from conda (anaconda.org neutronimaging channel)
-conda install -c conda-forge -c neutronimaging braggedgemodeling
+# or from conda (our anaconda.org neutronimaging channel)
+conda install neutronimaging::braggedgemodeling
 ```
 
 The distribution is named `braggedgemodeling` (the short name `bem` is already taken on PyPI) and the **import package is also `braggedgemodeling`**. Code written against the old `bem` module can add a one-line alias as a drop-in stop-gap:
@@ -47,7 +47,7 @@ pixi run test   # build the environment and run the test suite
 
 ## Documentation
 
-Please refer to https://ornlneutronimaging.github.io/braggedgemodeling for documentation
+Please refer to https://braggedge.readthedocs.io for documentation
 on installation, usage, and API.
 
 ## Community guidelines

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -72,7 +72,7 @@ Nothing is published until a tag is pushed — pushes and PRs only build/test.
   ```
 - **conda / anaconda.org**:
   ```bash
-  conda install -c conda-forge -c neutronimaging "braggedgemodeling=0.2.0"
+  conda install neutronimaging::braggedgemodeling=0.2.0
   ```
 - **GitHub Release** — appears at `releases/tag/v0.2.0` with the wheel, sdist,
   and `.conda` attached.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,6 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
-    "sphinx.ext.githubpages",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -28,9 +28,9 @@ Install from PyPI (pip)
 Install from conda (anaconda.org)
 ----------------------------------
 
-Conda packages are published to the ``neutronimaging`` channel::
+Conda packages are published to our ``neutronimaging`` channel::
 
-   $ conda install -c conda-forge -c neutronimaging braggedgemodeling
+   $ conda install neutronimaging::braggedgemodeling
 
 
 From source (pixi)

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -5,7 +5,7 @@ Tutorial
 
 Please see :ref:`installation` before start here.
 
-This tutorial also exists as a jupyter notebook: https://github.com/ornlneutronimaging/braggedgemodeling/blob/master/notebooks/tutorial.ipynb
+This tutorial also exists as a jupyter notebook: https://github.com/ornlneutronimaging/braggedgemodeling/blob/main/notebooks/tutorial.ipynb
 
 This tutorial walks through some basic steps of using braggedgemodeling for modeling of neutron Bragg edge spectrum.
 


### PR DESCRIPTION
Cosmetic tidy-up after the `master`→`main` rename and the Read the Docs switch. **No functional change.**

- **Conda install command** → `conda install neutronimaging::braggedgemodeling` (our anaconda.org `neutronimaging` channel, not conda-forge) in README, `docs/installation.rst`, and `RELEASING.md`.
- **README**: Documentation link → the live Read the Docs site (`https://braggedge.readthedocs.io`) instead of the stale `github.io` URL.
- **CI.yml / publish.yml**: drop the now-deleted `master` from the push triggers (keep `main`).
- **docs/tutorial.rst**: notebook link `blob/master` → `blob/main`.
- **docs/conf.py**: remove the vestigial `sphinx.ext.githubpages` extension (docs are on RTD now).

Verified locally: all pre-commit hooks pass; `pixi run -e docs build-docs` succeeds with **0 warnings**.

Note: the old `gh-pages` branch is now orphaned and can be deleted, but I left that to you since it's a branch deletion I didn't create.