### PR TITLE
license: correct to MIT + fix copyright holder to UT-Battelle

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2018 ORNL Neutron Data Sciences Group
+Copyright (c) 2017-2026, UT-Battelle, LLC (Oak Ridge National Laboratory)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "braggedgemodeling"
 description = "Bragg Edge modeling"
 dynamic = ["version"]
 requires-python = ">=3.12"
-license = { text = "BSD" }
+license = { text = "MIT" }
 keywords = ["instrument", "neutron", "imaging", "Bragg Edge"]
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Prep for the DOE CODE / ANAQUA software-release submission.

The repo `LICENSE` has always been the **MIT License**, but the packaging metadata mislabeled it as **BSD** (`setup.py` originally, carried into `pyproject.toml` during the modernization). This corrects the mismatch:

- **`pyproject.toml`**: `license` `BSD` → `MIT` (now matches the actual LICENSE file).
- **`LICENSE`**: copyright holder `ORNL Neutron Data Sciences Group` → `UT-Battelle, LLC (Oak Ridge National Laboratory)`, years `2017-2026`. This is the correct copyright holder for ORNL work under DOE contract DE-AC05-00OR22725 — as stated verbatim in the package's own JOSS paper Notice of Copyright — and matches the house style already applied to bm3dornl/rustpix.

No code change. All pre-commit hooks pass.